### PR TITLE
OK-233 : CXF upgrade, uudenlainen headereiden asettaminen interceptorilla

### DIFF
--- a/java-cxf/pom.xml
+++ b/java-cxf/pom.xml
@@ -83,6 +83,12 @@
             <version>1.7.25</version>
         </dependency>
         <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+            <version>1.7.25</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.apache.santuario</groupId>
             <artifactId>xmlsec</artifactId>
             <version>1.4.6</version>

--- a/java-cxf/pom.xml
+++ b/java-cxf/pom.xml
@@ -14,6 +14,11 @@
     <artifactId>java-cxf</artifactId>
     <version>0.3.0-SNAPSHOT</version>
     <!-- exclusions due <dependencyConvergence/> -->
+
+    <properties>
+        <cxf.version>3.3.2</cxf.version>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>junit</groupId>
@@ -24,7 +29,7 @@
         <dependency>
             <groupId>fi.vm.sade.java-utils</groupId>
             <artifactId>jetty-test-utils</artifactId>
-            <version>0.2.0-SNAPSHOT</version>
+            <version>0.2.1-SNAPSHOT</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>
@@ -36,32 +41,20 @@
 
         <dependency>
             <groupId>org.apache.cxf</groupId>
-            <artifactId>cxf-bundle</artifactId>
-            <version>2.5.1</version>
-            <scope>provided</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>commons-logging</groupId>
-                    <artifactId>commons-logging</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>commons-collections</groupId>
-                    <artifactId>commons-collections</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>commons-lang</groupId>
-                    <artifactId>commons-lang</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.apache.santuario</groupId>
-                    <artifactId>xmlsec</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-api</artifactId>
-                </exclusion>
-            </exclusions>
+            <artifactId>cxf-core</artifactId>
+            <version>${cxf.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.cxf</groupId>
+            <artifactId>cxf-rt-rs-client</artifactId>
+            <version>${cxf.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.ow2.asm</groupId>
+            <artifactId>asm</artifactId>
+            <version>5.2</version>
+        </dependency>
+
         <dependency>
             <groupId>commons-logging</groupId>
             <artifactId>commons-logging</artifactId>

--- a/java-cxf/src/test/resources/log4j.properties
+++ b/java-cxf/src/test/resources/log4j.properties
@@ -1,0 +1,11 @@
+# Root logger option
+log4j.rootLogger=INFO, CONSOLE
+
+# Direct log messages to stdout
+log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender
+log4j.appender.CONSOLE.layout=org.apache.log4j.PatternLayout
+log4j.appender.CONSOLE.layout.ConversionPattern=%d{ABSOLUTE} %5p %c{1}:%L - %m%n
+
+# Package specific logging configurations
+log4j.logger.org.springframework=INFO
+log4j.logger.fi.vm=DEBUG

--- a/jetty-test-utils/pom.xml
+++ b/jetty-test-utils/pom.xml
@@ -8,7 +8,7 @@
         <relativePath>..</relativePath>
     </parent>
     <artifactId>jetty-test-utils</artifactId>
-    <version>0.2.0-SNAPSHOT</version>
+    <version>0.2.1-SNAPSHOT</version>
     <packaging>jar</packaging>
     <dependencies>
         <dependency>
@@ -24,7 +24,7 @@
         <dependency>
             <groupId>com.sun.jersey</groupId>
             <artifactId>jersey-servlet</artifactId>
-            <version>1.17.1</version>
+            <version>1.19.4</version>
         </dependency>
         <dependency>
             <groupId>commons-codec</groupId>

--- a/legacy-caching-rest-client/pom.xml
+++ b/legacy-caching-rest-client/pom.xml
@@ -152,7 +152,7 @@
         <dependency>
             <groupId>fi.vm.sade.java-utils</groupId>
             <artifactId>jetty-test-utils</artifactId>
-            <version>0.2.0-SNAPSHOT</version>
+            <version>0.2.1-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Vanha OphRequestHeadersCxfInterceptor:ssa käytetty headereiden asettamisen tapa ei toiminut Valintalaskentakoostepalvelun testeissä.

Ja kun muutin toteutusta, tuli ongelmia vanhojen asm- ja cxf-kirjastojen kanssa Java 8:lla, joten päivitin ne.

Lisäsin myös java-cxf-modulin testiajoihin logituksen, jotta serveripään virheet näkyvät.