### PR TITLE
Korjaus OphHttpResponseImpl.toString inputstream konversioon

### DIFF
--- a/java-http/src/main/java/fi/vm/sade/javautils/http/OphHttpResponseHandlerImpl.java
+++ b/java-http/src/main/java/fi/vm/sade/javautils/http/OphHttpResponseHandlerImpl.java
@@ -1,10 +1,14 @@
 package fi.vm.sade.javautils.http;
 
 import fi.vm.sade.javautils.http.exceptions.UnhandledHttpStatusCodeException;
+
+import org.apache.http.ParseException;
 import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.util.EntityUtils;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Optional;
 import java.util.Set;
@@ -79,13 +83,13 @@ public class OphHttpResponseHandlerImpl<T> implements OphHttpResponseHandler<T> 
     }
 
     private String asTextAndClose() {
-        try (InputStream inputStream = this.response.getEntity().getContent()) {
-            return OphHttpResponseImpl.toString(inputStream);
+
+        try {
+            return EntityUtils.toString(this.response.getEntity(), StandardCharsets.UTF_8);
         } catch (IOException e) {
             throw new RuntimeException(e);
-        } finally {
-            this.close();
         }
+
     }
 
     private void close() {
@@ -95,6 +99,5 @@ public class OphHttpResponseHandlerImpl<T> implements OphHttpResponseHandler<T> 
             throw new RuntimeException(ioe);
         }
     }
-
 
 }

--- a/java-http/src/main/java/fi/vm/sade/javautils/http/OphHttpResponseImpl.java
+++ b/java-http/src/main/java/fi/vm/sade/javautils/http/OphHttpResponseImpl.java
@@ -1,13 +1,9 @@
 package fi.vm.sade.javautils.http;
 
-import org.apache.http.client.methods.CloseableHttpResponse;
-
-import java.io.BufferedInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
 import java.util.HashSet;
 import java.util.Set;
+
+import org.apache.http.client.methods.CloseableHttpResponse;
 
 public class OphHttpResponseImpl<T> implements OphHttpResponse<T> {
 
@@ -33,19 +29,6 @@ public class OphHttpResponseImpl<T> implements OphHttpResponse<T> {
     @Override
     public OphHttpResponseHandler<T> expectedStatus(int... statusArray) {
         return new OphHttpResponseHandlerImpl<>(this.response, statusArray, this.ophHttpCallBackSet);
-    }
-
-    static String toString(InputStream stream) throws IOException { // IO
-        try(BufferedInputStream bis = new BufferedInputStream(stream);
-            ByteArrayOutputStream buf = new ByteArrayOutputStream()) {
-            int result;
-            result = bis.read();
-            while(result != -1) {
-                buf.write((byte) result);
-                result = bis.read();
-            }
-            return buf.toString();
-        }
     }
 
 }


### PR DESCRIPTION
Merkistö menee rikki (windows ympäristössä) vanhalla toteutuksella.