### PR TITLE
HTTP-clientille all-args konstruktori.

### DIFF
--- a/java-http/pom.xml
+++ b/java-http/pom.xml
@@ -10,7 +10,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>java-http</artifactId>
-    <version>0.6.0-SNAPSHOT</version>
+    <version>0.6.1-SNAPSHOT</version>
 
     <properties>
         <apache.httpclient.version>4.5.12</apache.httpclient.version>

--- a/java-http/src/main/java/fi/vm/sade/javautils/http/OphHttpClient.java
+++ b/java-http/src/main/java/fi/vm/sade/javautils/http/OphHttpClient.java
@@ -54,13 +54,13 @@ public class OphHttpClient {
         private static final String CSRF = "CSRF";
     }
 
-    private LogUtil logUtil;
-    private CloseableHttpClient cachingClient;
-    private CookieStore cookieStore;
-    private Authenticator authenticator;
-    private String callerId;
+    private final LogUtil logUtil;
+    private final CloseableHttpClient cachingClient;
+    private final CookieStore cookieStore;
+    private final Authenticator authenticator;
+    private final String callerId;
 
-    private ThreadLocal<HttpContext> localContext = ThreadLocal.withInitial(BasicHttpContext::new);
+    private final ThreadLocal<HttpContext> localContext = ThreadLocal.withInitial(BasicHttpContext::new);
     private HashMap<String, Boolean> csrfCookiesCreateForHost = new HashMap<>();
 
     private OphHttpClient(Builder builder) {
@@ -182,7 +182,7 @@ public class OphHttpClient {
         try {
             return cachingClient.execute(request, localContext.get());
         } catch (IOException e) {
-            log.error("Failed to execute request: {}", e);
+            log.error("Failed to execute request: {}", request, e);
             throw new RuntimeException("Internal error calling " + request.getMethod() + "/" + request.getURI() + " (check logs): " + e.getMessage());
         }
     }

--- a/java-http/src/main/java/fi/vm/sade/javautils/http/auth/CasAuthenticator.java
+++ b/java-http/src/main/java/fi/vm/sade/javautils/http/auth/CasAuthenticator.java
@@ -39,6 +39,17 @@ public class CasAuthenticator implements Authenticator {
         addSpringSecSuffix = builder.addSpringSecSuffix;
     }
 
+    public CasAuthenticator(String webCasUrl, String username, String password, String casServiceUrl,
+                            String casServiceSessionInitUrl, boolean addSpringSecSuffix, String sessionCookieName) {
+        this.webCasUrl = webCasUrl;
+        this.username = username;
+        this.password = password;
+        this.casServiceUrl = casServiceUrl;
+        this.casServiceSessionInitUrl = casServiceSessionInitUrl;
+        this.addSpringSecSuffix = addSpringSecSuffix;
+        this.sessionCookieName = sessionCookieName;
+    }
+
     @Override
     public void clearSession() {
         serviceAsAUserTicket = null;
@@ -93,7 +104,7 @@ public class CasAuthenticator implements Authenticator {
         req.setHeader(X_PALVELUKUTSU_LAHETTAJA_KAYTTAJA_TUNNUS, callAsUser);
     }
 
-    public static class Builder{
+    public static class Builder {
         String webCasUrl;
         String username;
         String password;


### PR DESCRIPTION
Builderia ei voi käyttää XML-konfiguraatioissa, koska
se ei noudata beanien nimeämiskäytäntöä. Lisätty konstruktori
XML-konfiguraation mahdollistamiseksi.

Myös pari kosmeettista drive by -muutosta.